### PR TITLE
refactor(auth): rename updateFcmToken to registerFcmToken

### DIFF
--- a/app/composables/api-client-fetch.ts
+++ b/app/composables/api-client-fetch.ts
@@ -93,7 +93,7 @@ async function nativeApiFetch<T>(
   };
 
   // Debug logging for FCM token endpoint
-  if (url.includes('update-fcm-token')) {
+  if (url.includes('register-fcm-token')) {
     console.log('[nativeApiFetch] FCM Token Request Debug:');
     console.log('[nativeApiFetch] URL:', fullUrl);
     console.log('[nativeApiFetch] Auth token exists:', !!authToken);

--- a/app/composables/auth.ts
+++ b/app/composables/auth.ts
@@ -161,12 +161,12 @@ export const useAuth = () => {
   };
 
   /**
-   * Update FCM token for push notifications
+   * Register FCM token for push notifications
    * This should be called whenever the FCM token is received or refreshed
    * @param fcmToken - The FCM token from Firebase
    */
-  const updateFcmToken = async (fcmToken: string) => {
-    return await useApiClientFetch('/auth/update-fcm-token', {
+  const registerFcmToken = async (fcmToken: string) => {
+    return await useApiClientFetch('/auth/register-fcm-token', {
       method: 'POST',
       body: { fcm_token: fcmToken },
     });
@@ -181,7 +181,7 @@ export const useAuth = () => {
       const fcmToken = getFcmToken();
       if (fcmToken) {
         console.log('[Auth] Syncing FCM token after login...');
-        await updateFcmToken(fcmToken);
+        await registerFcmToken(fcmToken);
         console.log('[Auth] FCM token synced successfully');
       }
     } catch (error) {
@@ -204,7 +204,7 @@ export const useAuth = () => {
     requestPassword,
     resetPassword,
     sendEmailVerification,
-    updateFcmToken,
+    registerFcmToken,
     syncFcmToken,
   };
 };

--- a/docs/firebase-push-notification-setup.md
+++ b/docs/firebase-push-notification-setup.md
@@ -138,14 +138,14 @@ setOnNotificationAction((action) => {
 // Handle token refresh (optional - token is automatically sent to backend)
 setOnTokenReceived((newToken) => {
   console.log('New FCM Token:', newToken);
-  // Token is automatically sent to backend via /auth/update-fcm-token
+  // Token is automatically sent to backend via /auth/register-fcm-token
   // Add any additional custom logic here if needed
 });
 ```
 
 ### Sending Token to Backend
 
-The FCM token is **automatically sent to the backend** when it's received or refreshed. The plugin calls the `/auth/update-fcm-token` endpoint automatically.
+The FCM token is **automatically sent to the backend** when it's received or refreshed. The plugin calls the `/auth/register-fcm-token` endpoint automatically.
 
 **Automatic Token Sync:**
 - When the app starts and receives an FCM token, it's automatically sent to the backend
@@ -169,15 +169,15 @@ async function onUserLogin() {
 You can also use the auth composable directly:
 
 ```typescript
-const { updateFcmToken } = useAuth();
+const { registerFcmToken } = useAuth();
 
-// Manually update FCM token
-await updateFcmToken(token);
+// Manually register FCM token
+await registerFcmToken(token);
 ```
 
 **API Endpoint:**
 ```
-POST /auth/update-fcm-token
+POST /auth/register-fcm-token
 Content-Type: application/json
 
 {


### PR DESCRIPTION
Update function and endpoint naming from 'update-fcm-token' to 'register-fcm-token' for better semantic clarity. The term 'register' more accurately describes the action of associating an FCM token with a user account.

Changes include:
- Rename updateFcmToken() to registerFcmToken() in auth composable
- Update endpoint from /auth/update-fcm-token to /auth/register-fcm-token
- Update debug logging to reference new endpoint name
- Update documentation to reflect new function and endpoint names