### PR TITLE
feat(auth): add device identification to FCM token registration

### DIFF
--- a/app/composables/auth.ts
+++ b/app/composables/auth.ts
@@ -166,9 +166,17 @@ export const useAuth = () => {
    * @param fcmToken - The FCM token from Firebase
    */
   const registerFcmToken = async (fcmToken: string) => {
+    const { getOrCreateDeviceId, getDeviceType } = await import('~/plugins/003.push-notification.client');
+    const deviceId = await getOrCreateDeviceId();
+    const deviceType = getDeviceType();
+
     return await useApiClientFetch('/auth/register-fcm-token', {
       method: 'POST',
-      body: { fcm_token: fcmToken },
+      body: {
+        token: fcmToken,
+        device_id: deviceId,
+        device_type: deviceType,
+      },
     });
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thinkaction",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Include device_id and device_type in the FCM token registration payload to support multi-device push notification management. Also update API request body field from fcm_token to token.