### PR TITLE
fix(android): fix splash screen logo sizing and theme configuration

### DIFF
--- a/android/app/src/main/res/drawable-night/splash_screen.xml
+++ b/android/app/src/main/res/drawable-night/splash_screen.xml
@@ -6,6 +6,8 @@
     <!-- Centered logo -->
     <item>
         <bitmap
+            android:width="160dp"
+            android:height="160dp"
             android:gravity="center"
             android:src="@drawable/splash_logo" />
     </item>

--- a/android/app/src/main/res/drawable/splash_screen.xml
+++ b/android/app/src/main/res/drawable/splash_screen.xml
@@ -4,9 +4,12 @@
     <item android:drawable="@color/splash_background" />
     
     <!-- Centered logo -->
-    <item>
+    <item
+        android:width="160dp"
+        android:height="160dp"
+        android:gravity="center">
         <bitmap
-            android:gravity="center"
+            android:gravity="fill"
             android:src="@drawable/splash_logo" />
     </item>
 </layer-list>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -23,7 +23,9 @@
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
-    <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-        <item name="android:background">@drawable/splash_screen</item>
+    <style name="AppTheme.NoActionBarLaunch" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowBackground">@drawable/splash_screen</item>
     </style>
 </resources>


### PR DESCRIPTION
Set explicit 160dp dimensions for the splash screen logo in both light and night drawables to prevent scaling issues. Update the launch theme to inherit from Theme.AppCompat.DayNight.NoActionBar and use windowBackground for the splash drawable.